### PR TITLE
Fix wonky-ness on macOS

### DIFF
--- a/lilypichu.scss
+++ b/lilypichu.scss
@@ -7,6 +7,7 @@
 @forward 'stuff/settings';
 @forward 'stuff/friends';
 @forward 'stuff/overlay';
+@forward 'stuff/macos';
 @forward 'stuff/other';
 
 @import url('https://nyri4.github.io/donators/donators.css');

--- a/lilypichu.theme.css
+++ b/lilypichu.theme.css
@@ -3,7 +3,7 @@
 * @author Nyria#3863
 * @description A theme based on @Melonturtle_ stream design
 * @invite rtBQX5D3bD
-* @version 1.0
+* @version 1.1
 */
 @import url("https://nyri4.github.io/LilyPichu/main.css");
 

--- a/main.css
+++ b/main.css
@@ -1653,6 +1653,20 @@
   background-size: 100%;
 }
 
+/*
+ * Vbriese here, I did this real quick but I noticed you wrap your other SCSS styles in a :root selector.
+ * For some reason, the styles below just didn't work in a :root selector. (IDK I might be doing something dum.)
+ *
+ * On an unrelated note, it would help contributors if you let them know to compile using a command like this:
+ * sass -w lilypichu.scss main.css --no-source-map
+ */
+.platform-osx .wrapper-3NnKdC {
+  margin-top: 0;
+}
+.platform-osx .layers-3iHuyZ {
+  margin-top: 32px;
+}
+
 :root ::-webkit-input-placeholder, :root body, :root button, :root input, :root select, :root textarea {
   font-family: "Nunito" !important;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "icon": "assets/flower.png",
     "name": "LilyPichu",
     "description": "A theme based on @Melonturtle_ stream design",
-    "version": "1.0",
+    "version": "1.1",
     "author": "Nyria#3863",
     "theme": "lilypichu.theme.css",
     "consent": "false",

--- a/powercord_manifest.json
+++ b/powercord_manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "LilyPichu",
     "description": "A theme based on @Melonturtle_ stream design",
-    "version": "1.0",
+    "version": "1.1",
     "author": "Nyria#3863",
     "theme": "lilypichu.scss",
     "consent": "false",

--- a/stuff/_macos.scss
+++ b/stuff/_macos.scss
@@ -1,0 +1,17 @@
+/*
+ * Vbriese here, I did this real quick but I noticed you wrap your other SCSS styles in a :root selector.
+ * For some reason, the styles below just didn't work in a :root selector. (IDK I might be doing something dum.)
+ *
+ * On an unrelated note, it would help contributors if you let them know to compile using a command like this:
+ * sass -w lilypichu.scss main.css --no-source-map
+ */
+
+.platform-osx {
+  .wrapper-3NnKdC {
+    margin-top: 0;
+  }
+
+  .layers-3iHuyZ {
+    margin-top: 32px;
+  }
+}


### PR DESCRIPTION
I basically just added this:

```scss
.platform-osx {
  .wrapper-3NnKdC {
    margin-top: 0;
  }

  .layers-3iHuyZ {
    margin-top: 32px;
  }
}
```

IDK why you hesitated on fixing the macOS wonky-ness, but whatever, I did it for you.